### PR TITLE
Breeze in life

### DIFF
--- a/SecondLife.For.FastQueries/src/App_Config/Include/SecondLife.For.FastQueries.config
+++ b/SecondLife.For.FastQueries/src/App_Config/Include/SecondLife.For.FastQueries.config
@@ -6,6 +6,7 @@
     <fastQueryDatabases>
       <database id="web" singleInstance="true" type="SecondLife.For.FastQueries.ReuseFastQueryResultsDatabase, SecondLife.For.FastQueries" >
         <param ref="databases/database[@id='$(id)']" />
+        <CacheFastQueryResults>true</CacheFastQueryResults>
       </database>
     </fastQueryDatabases>
   </sitecore>

--- a/SecondLife.For.FastQueries/src/App_Config/Include/SecondLife.For.FastQueries.config
+++ b/SecondLife.For.FastQueries/src/App_Config/Include/SecondLife.For.FastQueries.config
@@ -1,0 +1,12 @@
+﻿<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+  <sitecore role:require="Standalone">
+    <services>
+      <configurator type="SecondLife.For.FastQueries.DependencyInjection.CustomFactoryRegistration, SecondLife.For.FastQueries"/>      
+    </services>
+    <fastQueryDatabases>
+      <database id="web" singleInstance="true" type="SecondLife.For.FastQueries.ReuseFastQueryResultsDatabase, SecondLife.For.FastQueries" >
+        <param ref="databases/database[@id='$(id)']" />
+      </database>
+    </fastQueryDatabases>
+  </sitecore>
+</configuration>

--- a/SecondLife.For.FastQueries/src/DefaultFactoryForCacheableFastQuery.cs
+++ b/SecondLife.For.FastQueries/src/DefaultFactoryForCacheableFastQuery.cs
@@ -7,6 +7,10 @@ using Sitecore.Diagnostics;
 
 namespace SecondLife.For.FastQueries
 {
+    /// <summary>
+    /// Finds databases under 'fastQueryDatabases' node (to avoid collisions with OOB Sitecore logic).
+    /// <para>Since databases are always registered as 'singleInstance' in config, we could cache instances.</para>
+    /// </summary>
     public sealed class DefaultFactoryForCacheableFastQuery : DefaultFactory
     {
         private static readonly char[] ForbiddenChars = "[\\\"*^';&></=]".ToCharArray();

--- a/SecondLife.For.FastQueries/src/DefaultFactoryForCacheableFastQuery.cs
+++ b/SecondLife.For.FastQueries/src/DefaultFactoryForCacheableFastQuery.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Sitecore.Abstractions;
+using Sitecore.Configuration;
+using Sitecore.Data;
+using Sitecore.Diagnostics;
+
+namespace SecondLife.For.FastQueries
+{
+    public sealed class DefaultFactoryForCacheableFastQuery : DefaultFactory
+    {
+        private static readonly char[] ForbiddenChars = "[\\\"*^';&></=]".ToCharArray();
+
+        private readonly ConcurrentDictionary<string, Database> _databases;
+
+        public DefaultFactoryForCacheableFastQuery(BaseComparerFactory comparerFactory, IServiceProvider serviceProvider) 
+            : base(comparerFactory, serviceProvider)
+        {
+            _databases = new ConcurrentDictionary<string, Database>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public override Database GetDatabase(string name, bool assert)
+        {
+            Assert.ArgumentNotNull(name, nameof(name));
+            if (name.IndexOfAny(ForbiddenChars) >= 0)
+            {
+                Assert.IsFalse(assert, nameof(assert));
+                return null;
+            }
+
+            if (_databases.TryGetValue(name, out var cached))
+            {
+                if (assert && cached == null)
+                {
+                    throw new InvalidOperationException($"Could not create database: {name}");
+                }
+            }
+
+            var configPath = "fastQueryDatabases/database[@id='" + name + "']";
+
+            if (CreateObject(configPath, assert: false) is Database database)
+            {
+                _databases.TryAdd(name, database);
+                return database;
+            }
+
+            database = base.GetDatabase(name, assert: false);
+            _databases.TryAdd(name, database);
+
+            if (assert && database == null)
+            {
+                throw new InvalidOperationException($"Could not create database: {name}");
+            }
+
+            return database;
+        }
+    }
+}

--- a/SecondLife.For.FastQueries/src/DependencyInjection/CustomFactoryRegistration.cs
+++ b/SecondLife.For.FastQueries/src/DependencyInjection/CustomFactoryRegistration.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 
@@ -8,6 +9,9 @@ namespace SecondLife.For.FastQueries.DependencyInjection
     {
         public void Configure(IServiceCollection serviceCollection)
         {
+            var defaultFactoryRegistration = serviceCollection.First(descriptor => descriptor.ServiceType == typeof(BaseFactory));            
+            serviceCollection.Remove(defaultFactoryRegistration);
+
             serviceCollection.AddSingleton<BaseFactory, DefaultFactoryForCacheableFastQuery>();
         }
     }

--- a/SecondLife.For.FastQueries/src/DependencyInjection/CustomFactoryRegistration.cs
+++ b/SecondLife.For.FastQueries/src/DependencyInjection/CustomFactoryRegistration.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Sitecore.Abstractions;
+using Sitecore.DependencyInjection;
+
+namespace SecondLife.For.FastQueries.DependencyInjection
+{
+    public sealed class CustomFactoryRegistration: IServicesConfigurator
+    {
+        public void Configure(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton<BaseFactory, DefaultFactoryForCacheableFastQuery>();
+        }
+    }
+}

--- a/SecondLife.For.FastQueries/src/DependencyInjection/CustomFactoryRegistration.cs
+++ b/SecondLife.For.FastQueries/src/DependencyInjection/CustomFactoryRegistration.cs
@@ -1,10 +1,15 @@
 ﻿using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Sitecore;
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 
 namespace SecondLife.For.FastQueries.DependencyInjection
 {
+    /// <summary>
+    /// Registers factory to provide home-baked databases with optional fast-query result caching.
+    /// </summary>
+    [UsedImplicitly]
     public sealed class CustomFactoryRegistration: IServicesConfigurator
     {
         public void Configure(IServiceCollection serviceCollection)

--- a/SecondLife.For.FastQueries/src/ReuseFastQueryResultsDatabase.cs
+++ b/SecondLife.For.FastQueries/src/ReuseFastQueryResultsDatabase.cs
@@ -22,11 +22,16 @@ using Version = Sitecore.Data.Version;
 
 namespace SecondLife.For.FastQueries
 {
+    /// <summary>
+    /// Optionally provides caching layer for fast query results on top of inner <see cref="Database"/>.
+    /// <para>Caching is controlled over <see cref="CacheFastQueryResults"/> config property.</para>
+    /// <para>The caching layer is scavenged when publish ends.</para>
+    /// </summary>
     public sealed class ReuseFastQueryResultsDatabase : Database
     {
         private readonly Database _database;
-        private readonly ConcurrentDictionary<string, Item> _singleItems = new ConcurrentDictionary<string, Item>(StringComparer.OrdinalIgnoreCase);
 
+        private readonly ConcurrentDictionary<string, Item> _singleItems = new ConcurrentDictionary<string, Item>(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, IReadOnlyCollection<Item>> _multipleItems = new ConcurrentDictionary<string, IReadOnlyCollection<Item>>(StringComparer.OrdinalIgnoreCase);
 
         public ReuseFastQueryResultsDatabase(Database database)
@@ -36,7 +41,7 @@ namespace SecondLife.For.FastQueries
         }
 
         [UsedImplicitly]
-        private bool CacheFastQueryResults { get; set; }
+        public bool CacheFastQueryResults { get; private set; }
 
         #region Useful code
 

--- a/SecondLife.For.FastQueries/src/ReuseFastQueryResultsDatabase.cs
+++ b/SecondLife.For.FastQueries/src/ReuseFastQueryResultsDatabase.cs
@@ -1,0 +1,209 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using Sitecore.Collections;
+using Sitecore.Data;
+using Sitecore.Data.Archiving;
+using Sitecore.Data.Clones;
+using Sitecore.Data.DataProviders;
+using Sitecore.Data.Eventing;
+using Sitecore.Data.Items;
+using Sitecore.Diagnostics;
+using Sitecore.Globalization;
+using Sitecore.Resources;
+using Sitecore.Workflows;
+using Version = Sitecore.Data.Version;
+
+namespace SecondLife.For.FastQueries
+{    
+    public sealed class ReuseFastQueryResultsDatabase : Database
+    {
+        private readonly Database _database;
+
+        public ReuseFastQueryResultsDatabase(Database database)
+        {
+            Assert.ArgumentNotNull(database, nameof(database));
+            _database = database;
+        }
+
+        #region Useful code
+
+        public override Item SelectSingleItem(string query)
+        {
+            return _database.SelectSingleItem(query);
+        }
+
+        public override Item[] SelectItems(string query)
+        {
+            return _database.SelectItems(query);
+        }
+
+        #endregion
+
+        #region Boilerplate to decorate database impl
+
+        public override bool CleanupDatabase() => _database.CleanupDatabase();
+
+        public override Item CreateItemPath(string path) => _database.CreateItemPath(path);
+
+        public override Item CreateItemPath(string path, TemplateItem template) => _database.CreateItemPath(path, template);
+
+        public override Item CreateItemPath(string path, TemplateItem folderTemplate, TemplateItem itemTemplate) => _database.CreateItemPath(path, folderTemplate, itemTemplate);
+
+        public override DataProvider[] GetDataProviders() => _database.GetDataProviders();
+
+        public override long GetDataSize(int minEntitySize, int maxEntitySize) => _database.GetDataSize(minEntitySize, maxEntitySize);
+
+        public override long GetDictionaryEntryCount() => _database.GetDictionaryEntryCount();
+
+        public override Item GetItem(ID itemId) => _database.GetItem(itemId);
+
+        public override Item GetItem(ID itemId, Language language) => _database.GetItem(itemId, language);
+
+        public override Item GetItem(ID itemId, Language language, Version version) => _database.GetItem(itemId, language, version);
+
+        public override Item GetItem(string path) => _database.GetItem(path);
+
+        public override Item GetItem(string path, Language language) => _database.GetItem(path, language);
+
+        public override Item GetItem(string path, Language language, Version version) => _database.GetItem(path, language, version);
+
+        public override Item GetItem(DataUri uri) => _database.GetItem(uri);
+
+        public override LanguageCollection GetLanguages() => _database.GetLanguages();
+
+        public override Item GetRootItem() => _database.GetRootItem();
+
+        public override Item GetRootItem(Language language) => _database.GetRootItem(language);
+
+        public override TemplateItem GetTemplate(ID templateId) => _database.GetTemplate(templateId);
+
+        public override TemplateItem GetTemplate(string fullName) => _database.GetTemplate(fullName);
+
+        public override ItemList SelectItemsUsingXPath(string query) => _database.SelectItemsUsingXPath(query);
+
+        public override Item SelectSingleItemUsingXPath(string query) => _database.SelectSingleItemUsingXPath(query);
+
+        public override AliasResolver Aliases => _database.Aliases;
+
+        public override List<string> ArchiveNames => _database.ArchiveNames;
+
+        public override DataArchives Archives => _database.Archives;
+
+        public override DatabaseCaches Caches => _database.Caches;
+
+        public override string ConnectionStringName
+        {
+            get => _database.ConnectionStringName;
+            set => _database.ConnectionStringName = value;
+        }
+
+        public override DataManager DataManager => _database.DataManager;
+
+        public override DatabaseEngines Engines => _database.Engines;
+
+        public override bool HasContentItem => _database.HasContentItem;
+
+        public override string Icon
+        {
+            get => _database.Icon;
+            set => _database.Icon = value;
+        }
+
+        public override ItemRecords Items => _database.Items;
+
+        public override Language[] Languages => _database.Languages;
+
+        public override BranchRecords Branches => _database.Branches;
+
+        public override string Name => _database.Name;
+
+        public override DatabaseProperties Properties => _database.Properties;
+
+        public override bool Protected
+        {
+            get => _database.Protected;
+            set => _database.Protected = value;
+        }
+
+        public override bool PublishVirtualItems
+        {
+            get => _database.PublishVirtualItems;
+            set => _database.PublishVirtualItems = value;
+        }
+
+        public override bool ReadOnly
+        {
+            get => _database.ReadOnly;
+            set => _database.ReadOnly = value;
+        }
+
+        public override DatabaseRemoteEvents RemoteEvents => _database.RemoteEvents;
+
+        public override ResourceItems Resources => _database.Resources;
+
+        public override bool SecurityEnabled
+        {
+            get => _database.SecurityEnabled;
+            set => _database.SecurityEnabled = value;
+        }
+
+        public override Item SitecoreItem => _database.SitecoreItem;
+
+        public override TemplateRecords Templates => _database.Templates;
+
+        public override IWorkflowProvider WorkflowProvider
+        {
+            get => _database.WorkflowProvider;
+            set => _database.WorkflowProvider = value;
+        }
+
+        public override NotificationProvider NotificationProvider
+        {
+            get => _database.NotificationProvider;
+            set => _database.NotificationProvider = value;
+        }
+
+        #endregion
+
+        #region Sitecore technical debt - internal prop in abstract class =\
+
+        private volatile DataProviderCollection _dataProviders;
+        private readonly object _lock = new object();
+
+        protected override DataProviderCollection DataProviders
+        {
+            get
+            {
+                var copy = _dataProviders;
+
+                if (copy != null)
+                {
+                    return copy;
+                }
+
+                lock (_lock)
+                {
+                    if (_dataProviders != null)
+                    {
+                        return _dataProviders;
+                    }
+
+                    var providers = _database.GetDataProviders();
+
+                    var collection = new DataProviderCollection();
+
+                    foreach (var provider in providers)
+                    {
+                        collection.Add(provider);
+                    }
+
+                    Interlocked.CompareExchange(ref _dataProviders, collection, comparand: null);
+                }
+
+                return _dataProviders;
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fast query is known to be translated into direct SQL statement.
Web database is known to be updated only by publishing ending with event (like `publish:end`).

It leaves space for caching FastQuery results to avoid hammering SQL server.

The technical implementation - decorator for Sitecore database for SelectItem methods.
